### PR TITLE
Fix when range date_picker is cleared

### DIFF
--- a/vizro-core/src/vizro/models/_components/form/date_picker.py
+++ b/vizro-core/src/vizro/models/_components/form/date_picker.py
@@ -10,6 +10,7 @@ except ImportError:  # pragma: no cov
 
 
 from datetime import date
+from dash import clientside_callback, dcc, ClientsideFunction, Input, Output, State
 
 import dash_bootstrap_components as dbc
 
@@ -56,6 +57,21 @@ class DatePicker(VizroBaseModel):
     def build(self):
         init_value = self.value or ([self.min, self.max] if self.range else self.min)  # type: ignore[list-item]
 
+        output = [
+            Output(self.id, "value"),
+            Output(f"{self.id}_input_store", "data"),
+        ]
+        inputs = [
+            Input(self.id, "value"),
+            State(f"{self.id}_input_store", "data"),
+        ]
+
+        clientside_callback(
+            ClientsideFunction(namespace="date_picker", function_name="update_date_picker_values"),
+            output=output,
+            inputs=inputs,
+        )
+
         date_picker = dmc.DatePickerInput(
             id=self.id,
             minDate=self.min,
@@ -64,7 +80,7 @@ class DatePicker(VizroBaseModel):
             persistence=True,
             persistence_type="session",
             type="range" if self.range else "default",
-            allowSingleDateInRange= True,
+            allowSingleDateInRange=True,
             className="datepicker",
             # removes the default red color for  weekend days
             styles={"day": {"color": "var(--mantine-color-text"}},
@@ -74,5 +90,6 @@ class DatePicker(VizroBaseModel):
             children=[
                 dbc.Label(children=self.title, html_for=self.id) if self.title else None,
                 date_picker,
+                dcc.Store(id=f"{self.id}_input_store", storage_type="session", data=init_value),
             ],
         )

--- a/vizro-core/src/vizro/static/js/models/date_picker.js
+++ b/vizro-core/src/vizro/static/js/models/date_picker.js
@@ -1,0 +1,29 @@
+function update_date_picker_values(value, input_store) {
+  if (Array.isArray(value) && value[1] === null) {
+    if (value[0] !== null) {
+      // The user starts selecting a range
+      // For example: value=["2025-01-01", null]
+      // No updates to the value or input store.
+      // Ideally, this date_picker should not be triggered in after date_picker selection is finished.
+      return dash_clientside.no_update;
+    }
+    if (value[0] === null) {
+      // The user started selecting a range and then unfocused the date_picker by clicking somewhere else
+      // value=[null, null]
+      // Update the date_picker value with the previous value from input store
+      return [input_store, dash_clientside.no_update];
+    }
+  }
+
+  // date_picker is properly selected
+  // For example: value=["2025-01-01", "2025-01-02"]
+  // Update the input store
+  return [dash_clientside.no_update, value];
+}
+
+window.dash_clientside = {
+  ...window.dash_clientside,
+  date_picker: {
+    update_date_picker_values: update_date_picker_values,
+  },
+};


### PR DESCRIPTION
## Description
If a user selects one of two values in the `type="range"` - `dmc.DatePickerInput`, and then clicks somewhere else on the page, `[null, null]` will be set in the component. This PR enables that the previously selected value (that was correct e.g. `["2025-01-01", "2025-05-05"]`) overwrites the `[null, null]` when this happens. So this bug is solved.

There's another problem that I wasn't able to solve with the javascript code or `dmc.DatePickerInput` configuration. So, when user selects the first value for the `type="range"` - `dmc.DatePickerInput`, all callbacks where this component is a `dcc.Input` will be triggered. Component value in that case is for example `["2025-01-01", null]`. Vizro in that case return an empty `data_frame` if this component is used as a `vm.Filter` (so this partially solves the problem).

So, selecting a complete value for this component means two requests to the server which is a bit odd:
1. The first request when only one value is selected (then an empty data_frame is returned for all its filter targets).
2. The second request when the second value is selected (then it works properly).

This problem (that I wasn't able to solve) happens with the `dmc==0.15.0` but did not happen with the `dmc==0.12.0`.
For the `dmc==0.12.0`, callbacks are triggered only after the second value is selected. 

## Screenshot

## Notice

- [x] I acknowledge and agree that, by checking this box and clicking "Submit Pull Request":

    - I submit this contribution under the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt) and represent that I am entitled to do so on behalf of myself, my employer, or relevant third parties, as applicable.
    - I certify that (a) this contribution is my original creation and / or (b) to the extent it is not my original creation, I am authorized to submit this contribution on behalf of the original creator(s) or their licensees.
    - I certify that the use of this contribution as authorized by the Apache 2.0 license does not violate the intellectual property rights of anyone else.
    - I have not referenced individuals, products or companies in any commits, directly or indirectly.
    - I have not added data or restricted code in any commits, directly or indirectly.
